### PR TITLE
Revert "chore(deps): update quay.io/kairos/debian docker tag to bookworm-standard-amd64-generic-v3.2.1-k3sv1.30.5-k3s1"

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/debian:bookworm-standard-amd64-generic-v3.2.1-k3sv1.30.5-k3s1
+FROM quay.io/kairos/debian:bookworm-standard-amd64-generic-v3.2.0-k3sv1.30.5-k3s1
 
 COPY rootfs/ /
 


### PR DESCRIPTION
Reverts tyzbit/kairos-distros#15